### PR TITLE
Bugfix: Now the company can be selected with filter

### DIFF
--- a/src/app/modules/workflow/subpages/script/script.component.ts
+++ b/src/app/modules/workflow/subpages/script/script.component.ts
@@ -140,8 +140,10 @@ export class ScriptComponent implements OnInit, AfterViewInit {
 
   async onCompanySelect(event: Empresa) {
     this.company = event;
-    await refresh();
-    this.selectedIndex = 1;
+    if (this.company) {
+      await refresh();
+      this.selectedIndex = 1;
+    }
   }
 
   navigate(page: number) {


### PR DESCRIPTION
### Qual era o problema?

> Na tela de "Novo Projeto", na aba de "Empresa", quando havia algum filtro ativo, a empresa não era selecionada (na verdade era, porém a aba que não era atualizada) automaticamente.

### Como ele foi resolvido? 

> Devido ao comportamento "genérico" da tabela, quando ela era reiniciada, o método de selecionar empresa era chamado. Para evitar isto, foi adicionada uma validação simples validando se a empresa selecionada era diferente de null.

### Qual o resultado esperado? 

> Ao selecionar uma empresa - mesmo que com filtro - a aba deve ser alterada automaticamente para "Material".
