### PR TITLE
Changes: Text 'Fornecedor' or 'Cliente' changed to 'Descricao'

### DIFF
--- a/src/app/modules/transacoes/transaction-detail/transaction-detail.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/transaction-detail.component.ts
@@ -440,11 +440,11 @@ export class TransactionDetailComponent implements OnInit, OnDestroy {
   descricao(): RuleConfig {
     return {
       selectable: true,
-      title: this.buttonLabel,
+      title: 'Descrição',
       values: [
         {
           key: 'descricao',
-          label: this.buttonLabel,
+          label: 'Descrição',
           pattern: DEFAULT_CHIP_PATTERN,
           value: this.entry.descricao
         }

--- a/src/app/shared/utils/entry.utils.ts
+++ b/src/app/shared/utils/entry.utils.ts
@@ -13,7 +13,7 @@ export class EntryUtils {
     const labels = {
       DATAMOVIMENTO:       'Data',
       DOCUMENTO:           'Documento',
-      DESCRICAO:           'Fornecedor / Cliente',
+      DESCRICAO:           'Descrição',
       PORTADOR:            'Banco',
       TIPOPLANILHA:        'Tipo da Planilha',
       CONTAMOVIMENTO:      'Conta',
@@ -37,11 +37,6 @@ export class EntryUtils {
       NENHUM:              '*'
     };
 
-    if (reference.tipoLancamento === 1) {
-      labels.DESCRICAO = 'Fornecedor';
-    } else if (reference.tipoLancamento === 2) {
-      labels.DESCRICAO = 'Cliente';
-    }
     if (reference.labelComplemento01) {
       labels.COMPLEMENTO01 = reference.labelComplemento01;
     }


### PR DESCRIPTION
### Qual era o problema?

> Campo "Fornecedor" ou "Cliente" não era claro o suficiente

### Como ele foi resolvido? 

> Campos que apresentavam a palavra "Fornecedor" ou "Cliente" foram alterados para "Descrição"

### Qual o resultado esperado? 

> Nas telas de Última Digitação, Regras, Históricos, Modal de Históricos e Modal de Regras, o campo deve passar a ser apresentado como "Descrição"
