### PR TITLE
Hotfix/g iaf sf yi

### DIFF
--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.html
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.html
@@ -87,7 +87,7 @@
     <tr mat-row class="w-100" *matRowDef="let row; columns: displayedColumns();">
     </tr>
   </table>
-  <mat-paginator [length]="pageInfo.totalElements" [pageSize]="pageInfo.pageSize" [pageSizeOptions]="[5, 10, 20]" (page)="onScroll($event)" *ngIf="info?.length">
+  <mat-paginator [length]="pageInfo.totalElements" [pageSize]="pageInfo.pageSize" [pageSizeOptions]="[5, 10, 20]" (page)="onPageChange($event)" *ngIf="info?.length">
   </mat-paginator>
 
 </div>

--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
@@ -46,7 +46,7 @@ export class RuleGridComponent implements OnInit, GenericPagination {
         .subscribe(imports => {
           this.info = imports.records;
           this.pageInfo = imports.pageInfo;
-          this.page++;
+          // this.page++;
           this._toast.hideSnack();
         });
     }

--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
@@ -45,7 +45,6 @@ export class RuleGridComponent implements OnInit, GenericPagination {
         .subscribe(imports => {
           this.info = imports.records;
           this.pageInfo = imports.pageInfo;
-          // this.page++;
           this._toast.hideSnack();
         });
   }
@@ -55,7 +54,6 @@ export class RuleGridComponent implements OnInit, GenericPagination {
   }
 
   onPageChange(event: PageEvent) {
-    console.log(event);
     this.page = event.pageIndex;
     this.nextPage(event.pageSize);
   }

--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
@@ -39,11 +39,12 @@ export class RuleGridComponent implements OnInit, GenericPagination {
     if (this.hasNext()) {
       this.isFetching = true;
       this._toast.showSnack('Aguardando resposta');
+      const searchCriteria = { cnpjEmpresa: this.data.company.cnpj, pageIndex: this.page, pageSize, tipoConta: 0, ativo: true };
       this._service
-        .getByRulePaginated(this.data.rules, this.data.company, this.page, pageSize)
+        .fetchByRule(this.data.rules, searchCriteria)
         .pipe(finalize(() => this.isFetching = false))
         .subscribe(imports => {
-          this.info = imports.records
+          this.info = imports.records;
           this.pageInfo = imports.pageInfo;
           this.page++;
           this._toast.hideSnack();

--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
@@ -10,7 +10,7 @@ import { Lancamento } from '@shared/models/Lancamento';
 import { PostFormatRule } from '@shared/models/Rule';
 import { Empresa } from '@shared/models/Empresa';
 import { finalize } from 'rxjs/operators';
-import { MatPaginator } from '@angular/material';
+import { MatPaginator, PageEvent } from '@angular/material';
 
 @Component({
   templateUrl: './rule-grid.component.html'
@@ -56,7 +56,8 @@ export class RuleGridComponent implements OnInit, GenericPagination {
     return !this.pageInfo || this.pageInfo.hasNext;
   }
 
-  onScroll(event: MatPaginator) {
+  onPageChange(event: PageEvent) {
+    console.log(event);
     this.page = event.pageIndex;
     this.nextPage(event.pageSize);
   }

--- a/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/rule-creator/rule-grid.component.ts
@@ -36,7 +36,6 @@ export class RuleGridComponent implements OnInit, GenericPagination {
   }
 
   nextPage(pageSize = 5): void {
-    if (this.hasNext()) {
       this.isFetching = true;
       this._toast.showSnack('Aguardando resposta');
       const searchCriteria = { cnpjEmpresa: this.data.company.cnpj, pageIndex: this.page, pageSize, tipoConta: 0, ativo: true };
@@ -49,7 +48,6 @@ export class RuleGridComponent implements OnInit, GenericPagination {
           // this.page++;
           this._toast.hideSnack();
         });
-    }
   }
 
   hasNext() {

--- a/src/app/modules/transacoes/transaction-detail/transaction-detail.component.html
+++ b/src/app/modules/transacoes/transaction-detail/transaction-detail.component.html
@@ -117,7 +117,7 @@
               type="button"
               class="btn btn-primary col mx-2"
               (click)="regra()"
-              value="Não é fornecedor"
+              [value]="getRuleButtonDescription()"
               [matTooltip]="info.rule"
             />
             <input

--- a/src/app/modules/transacoes/transaction-detail/transaction-detail.component.ts
+++ b/src/app/modules/transacoes/transaction-detail/transaction-detail.component.ts
@@ -400,6 +400,18 @@ export class TransactionDetailComponent implements OnInit {
     });
   }
 
+  /**
+   * @description Obtém o label do botão de regras
+   * @returns o label
+   */
+  public getRuleButtonDescription() {
+    switch (this.entry.tipoLancamento) {
+      case TipoLancamento.PAGAMENTOS:   return 'Não é fornecedor'
+      case TipoLancamento.RECEBIMENTOS: return 'Não é cliente'
+      default:                          return 'Regra'
+    }
+  }
+
   descricao(): RuleConfig {
     return {
       selectable: true,

--- a/src/app/shared/services/lancamento.service.ts
+++ b/src/app/shared/services/lancamento.service.ts
@@ -59,7 +59,9 @@ export class LancamentoService {
     return this.http.post<Lancamento>(url, {}, 'Falha ao vincular lançamento a uma conta de fornecedor!');
   }
 
-  // @Deprecated('Prefer to use fetchByRule directly')
+  /**
+   * @deprecated
+   */
   public getByRulePaginated(rules: PostFormatRule[], e: Empresa, page: number, pageSize: number) {
     const searchCriteria = { cnpjEmpresa: e.cnpj, pageIndex: page, pageSize, tipoConta: 0, ativo: true };
     return this.fetchByRule(rules, searchCriteria);

--- a/tslint.json
+++ b/tslint.json
@@ -46,7 +46,7 @@
       "ignore-params"
     ],
     "no-non-null-assertion": true,
-    "no-redundant-jsdoc": true,
+    "no-redundant-jsdoc": false,
     "no-switch-case-fall-through": true,
     "no-use-before-declare": true,
     "no-var-requires": false,


### PR DESCRIPTION
### Qual era o problema?

> Na lista de lançamentos afetados por regra, quando se chegava no final da lista, não era possível voltar

### Como ele foi resolvido? 

> Parte do código ainda estava utilizando a abordagem antiga - onde, ao invés do MatPaginator, havia um ScrollTracker -, por isso ele só permitia que ações fossem tomadas enquanto houvesse uma nova página.

### Qual o resultado esperado? 

> A lista de lançamentos afetados deve ser totalmente responsiva (não no sentido habitual, mas no sentido de responder às ordens do usuário)
